### PR TITLE
PSA-39868 Add missing Intel BT firmware for AX211, 9460/9560, AX200

### DIFF
--- a/build/base-image/Dockerfile
+++ b/build/base-image/Dockerfile
@@ -27,7 +27,7 @@ RUN yes | unminimize > /dev/null 2>&1
 RUN apt-get install -y -qq $(apt-cache depends linux-image-generic | grep -P 'Depends:\s+linux-image-\d|Depends:\s+linux-modules-extra-' | cut -d ':' -f2 | tr -d "<> ") > /dev/null 2>&1
 
 # Installing additional firmware/drivers for Intel and AMD CPUs, GPUs, WiFi, and Bluetooth.
-# Bluetooth firmware: ibt-0041 (AX210), ibt-19 (AX201), ibt-0093 (AX211), ibt-17 (9460/9560 JfP), ibt-20 (AX200).
+# Bluetooth firmware: ibt-0041 (AX210), ibt-19 (AX201), ibt-0093 (AX211), ibt-17 (9460/9560 JfP), ibt-20 (AX200), qca (QCA9377).
 RUN bash -c 'apt-get install -y -qq intel-microcode && \
     apt-get install -y -qq amd64-microcode && \
     apt-get download linux-firmware && \
@@ -41,6 +41,9 @@ RUN bash -c 'apt-get install -y -qq intel-microcode && \
     cp /tmp/linux-firmware/usr/lib/firmware/intel/ibt-0093-* /lib/firmware/intel/ && \
     cp /tmp/linux-firmware/usr/lib/firmware/intel/ibt-17-* /lib/firmware/intel/ && \
     cp /tmp/linux-firmware/usr/lib/firmware/intel/ibt-20-* /lib/firmware/intel/ && \
+    mkdir /lib/firmware/qca/ && \
+    cp /tmp/linux-firmware/usr/lib/firmware/qca/rampatch_usb_* /lib/firmware/qca/ && \
+    cp /tmp/linux-firmware/usr/lib/firmware/qca/nvm_usb_* /lib/firmware/qca/ && \
     mkdir /lib/firmware/amdgpu/ && \ 
     cp /tmp/linux-firmware/usr/lib/firmware/amdgpu/raven* /lib/firmware/amdgpu/ && \
     cp /tmp/linux-firmware/usr/lib/firmware/amdgpu/polaris* /lib/firmware/amdgpu/ && \

--- a/build/base-image/Dockerfile
+++ b/build/base-image/Dockerfile
@@ -26,7 +26,8 @@ RUN yes | unminimize > /dev/null 2>&1
 # Resolving the current stable kernel version via the metapackage "linux-image-generic" and installing it. Can be hardcoded if necessary.
 RUN apt-get install -y -qq $(apt-cache depends linux-image-generic | grep -P 'Depends:\s+linux-image-\d|Depends:\s+linux-modules-extra-' | cut -d ':' -f2 | tr -d "<> ") > /dev/null 2>&1
 
-# Installing additional firmware/drivers for Intel and AMD CPUs, GPUs, WiFi, and Bluetooth. Also copy documentation.
+# Installing additional firmware/drivers for Intel and AMD CPUs, GPUs, WiFi, and Bluetooth.
+# Bluetooth firmware: ibt-0041 (AX210), ibt-19 (AX201), ibt-0093 (AX211), ibt-17 (9460/9560 JfP), ibt-20 (AX200).
 RUN bash -c 'apt-get install -y -qq intel-microcode && \
     apt-get install -y -qq amd64-microcode && \
     apt-get download linux-firmware && \
@@ -34,9 +35,12 @@ RUN bash -c 'apt-get install -y -qq intel-microcode && \
     mkdir /lib/firmware/i915/ && \
     cp /tmp/linux-firmware/usr/lib/firmware/i915/* /lib/firmware/i915/ && \
     cp -r /tmp/linux-firmware/usr/lib/firmware/iwlwifi-* /lib/firmware/ && \
-    mkdir /lib/firmware/intel/ && \ 
+    mkdir /lib/firmware/intel/ && \
     cp /tmp/linux-firmware/usr/lib/firmware/intel/ibt-0041-0041* /lib/firmware/intel/ && \
     cp /tmp/linux-firmware/usr/lib/firmware/intel/ibt-19-0-4* /lib/firmware/intel/ && \
+    cp /tmp/linux-firmware/usr/lib/firmware/intel/ibt-0093-* /lib/firmware/intel/ && \
+    cp /tmp/linux-firmware/usr/lib/firmware/intel/ibt-17-* /lib/firmware/intel/ && \
+    cp /tmp/linux-firmware/usr/lib/firmware/intel/ibt-20-* /lib/firmware/intel/ && \
     mkdir /lib/firmware/amdgpu/ && \ 
     cp /tmp/linux-firmware/usr/lib/firmware/amdgpu/raven* /lib/firmware/amdgpu/ && \
     cp /tmp/linux-firmware/usr/lib/firmware/amdgpu/polaris* /lib/firmware/amdgpu/ && \


### PR DESCRIPTION
  ## Summary
  - Only AX210 (`ibt-0041`) and AX201 (`ibt-19`) Bluetooth firmware was included in the base image
  - 325 of 538 BT-equipped thinclients had adapters stuck in DOWN state due to missing firmware
  - 17 OptiPlex 3070 units with QCA9377 chips had no firmware at all (`qca/` directory missing)
  - Adds Intel firmware for AX211 (`ibt-0093`), 9460/9560 JfP (`ibt-17`), AX200 (`ibt-20`)
  - Adds Qualcomm firmware for QCA9377 (`rampatch_usb_*`, `nvm_usb_*`)
  - ~5.4 MB image size increase (compressed `.zst` firmware files)

  Affected devices (from scan of 619 thinclients):

  | Chip | DOWN count | Firmware added | Affected hardware |
  |------|-----------|----------------|-------------------|
  | Intel AX211 | 278 | `ibt-0093-*` | OptiPlex Micro 7020, OptiPlex Micro 7010, OptiPlex 3070, NUC13 |
  | Intel 9460/9560 JfP | 44 | `ibt-17-*` | HP EliteDesk 800 G4, NUC7, NUC8 |
  | Intel AX200 | 3 | `ibt-20-*` | HP EliteDesk 800 G5 |
  | Qualcomm QCA9377 | 17 | `qca/rampatch_usb_*`, `qca/nvm_usb_*` | OptiPlex 3070 |

  Related: [PSA-39868](https://jiradg.atlassian.net/browse/PSA-39868)


[PSA-39868]: https://jiradg.atlassian.net/browse/PSA-39868?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ