### PR TITLE
Route security updates through mirror fallback, add apt timeout

### DIFF
--- a/build/base-image/Dockerfile
+++ b/build/base-image/Dockerfile
@@ -5,9 +5,10 @@ FROM ubuntu:24.04
 ENV DEBIAN_FRONTEND=noninteractive DEBIAN_PRIORITY=critical
 
 # Configure apt to retry on transient mirror errors
-RUN echo 'Acquire::Retries "3";' > /etc/apt/apt.conf.d/80-retries
+RUN echo 'Acquire::Retries "3";' > /etc/apt/apt.conf.d/80-retries && \
+    echo 'Acquire::http::Timeout "10";' >> /etc/apt/apt.conf.d/80-retries
 
-# Replace default Ubuntu sources with mirror fallback chain (init7 -> switch.ch -> archive.ubuntu.com)
+# Replace default Ubuntu sources with mirror fallback chain (init7 -> switch.ch -> archive.ubuntu.com, 10s timeout)
 RUN rm -f /etc/apt/sources.list.d/ubuntu.sources
 COPY mirrors.list /etc/apt/mirrors.list
 COPY alternative-mirrors.list /etc/apt/sources.list.d/alternative-mirrors.list

--- a/build/base-image/alternative-mirrors.list
+++ b/build/base-image/alternative-mirrors.list
@@ -1,5 +1,5 @@
-# Apt mirrors with fallback: init7 -> switch.ch -> archive.ubuntu.com
+# Apt mirrors with fallback: init7 -> switch.ch -> archive.ubuntu.com (10s timeout)
 deb mirror+file:/etc/apt/mirrors.list questing main restricted universe multiverse
 deb mirror+file:/etc/apt/mirrors.list questing-updates main restricted universe multiverse
 deb mirror+file:/etc/apt/mirrors.list questing-backports main restricted universe multiverse
-deb http://security.ubuntu.com/ubuntu questing-security main restricted universe multiverse
+deb mirror+file:/etc/apt/mirrors.list questing-security main restricted universe multiverse


### PR DESCRIPTION
Route questing-security through mirror+file fallback chain instead of security.ubuntu.com
Add 10s HTTP timeout so slow mirrors fail fast to next fallback