### PR TITLE
Remove archive.ubuntu.com from apt mirror list

### DIFF
--- a/build/base-image/Dockerfile
+++ b/build/base-image/Dockerfile
@@ -8,7 +8,7 @@ ENV DEBIAN_FRONTEND=noninteractive DEBIAN_PRIORITY=critical
 RUN echo 'Acquire::Retries "3";' > /etc/apt/apt.conf.d/80-retries && \
     echo 'Acquire::http::Timeout "10";' >> /etc/apt/apt.conf.d/80-retries
 
-# Replace default Ubuntu sources with mirror fallback chain (init7 -> switch.ch -> archive.ubuntu.com, 10s timeout)
+# Replace default Ubuntu sources with mirror fallback chain (init7 -> switch.ch, 10s timeout)
 RUN rm -f /etc/apt/sources.list.d/ubuntu.sources
 COPY mirrors.list /etc/apt/mirrors.list
 COPY alternative-mirrors.list /etc/apt/sources.list.d/alternative-mirrors.list

--- a/build/base-image/alternative-mirrors.list
+++ b/build/base-image/alternative-mirrors.list
@@ -1,4 +1,4 @@
-# Apt mirrors with fallback: init7 -> switch.ch -> archive.ubuntu.com (10s timeout)
+# Apt mirrors with fallback: init7 -> switch.ch (10s timeout)
 deb mirror+file:/etc/apt/mirrors.list questing main restricted universe multiverse
 deb mirror+file:/etc/apt/mirrors.list questing-updates main restricted universe multiverse
 deb mirror+file:/etc/apt/mirrors.list questing-backports main restricted universe multiverse

--- a/build/base-image/mirrors.list
+++ b/build/base-image/mirrors.list
@@ -1,3 +1,2 @@
 http://mirror.init7.net/ubuntu/
 http://mirror.switch.ch/ftp/ubuntu/
-http://archive.ubuntu.com/ubuntu/


### PR DESCRIPTION
Remove archive.ubuntu.com — causes OOM kills during uncached Docker builds due to slow downloads keeping packages in memory